### PR TITLE
Replace casual library with bespoke random module to avoid fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   "dependencies": {
     "graphql-tools": "^4.0.4",
     "object-hash": "^1.3.1",
-    "seedrandom": "^3.0.5",
     "uuid": "^8.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,21 +47,22 @@
     "babel-core": "^7.0.0-0",
     "babel-jest": "^23.4.2",
     "del-cli": "^1.1.0",
-    "faker": "^4.1.0",
     "flow-bin": "0.89",
     "flow-copy-source": "^2.0.2",
     "flow-typed": "^2.5.1",
-    "graphql": "^0.14.6",
+    "graphql": "14.6.0",
     "husky": "^1.3.1",
     "jest": "^23.5.0",
     "lint-staged": "^8.1.1",
     "lodash": "^4.17.15",
-    "prettier": "^1.16.2"
+    "prettier": "^1.16.2",
+    "uuid-validate": "^0.0.3"
   },
   "dependencies": {
-    "casual": "^1.6.2",
     "graphql-tools": "^4.0.4",
-    "object-hash": "^1.3.1"
+    "object-hash": "^1.3.1",
+    "seedrandom": "^3.0.5",
+    "uuid": "^8.1.0"
   },
   "peerDependencies": {
     "graphql": "^0.13.0 || ^14.0.0"

--- a/src/__tests__/random.test.js
+++ b/src/__tests__/random.test.js
@@ -1,0 +1,73 @@
+import * as random from '../random';
+import validate from 'uuid-validate';
+
+describe('random', () => {
+  it('Generates random boolean values', () => {
+    let hasTrue = false;
+    let hasFalse = false;
+    for (let i = 0; i < 10; i++) {
+      if (random.getBoolean()) {
+        hasTrue = true;
+      } else {
+        hasFalse = true;
+      }
+    }
+    expect(hasTrue).toBeTruthy();
+    expect(hasFalse).toBeTruthy();
+  });
+
+  it('Generates random int values', () => {
+    let hasMinusThree = false;
+    let hasPlusThree = false;
+    for (let i = 0; i < 50; i++) {
+      const rand = random.getInt(-3, 3);
+      expect(rand).toBeGreaterThanOrEqual(-3);
+      expect(rand).toBeLessThanOrEqual(3);
+      if (rand === -3) {
+        hasMinusThree = true;
+      }
+      if (rand === 3) {
+        hasPlusThree = true;
+      }
+    }
+    expect(hasMinusThree).toBeTruthy();
+    expect(hasPlusThree).toBeTruthy();
+  });
+
+  it('Generates random float values', () => {
+    let hasMinusThrees = false;
+    let hasPlusThrees = false;
+    for (let i = 0; i < 50; i++) {
+      const rand = random.getFloat(-4, 4);
+      expect(rand).toBeGreaterThanOrEqual(-4);
+      expect(rand).toBeLessThanOrEqual(4);
+      if (rand <= -3) {
+        hasMinusThrees = true;
+      }
+      if (rand >= 3) {
+        hasPlusThrees = true;
+      }
+    }
+    expect(hasMinusThrees).toBeTruthy();
+    expect(hasPlusThrees).toBeTruthy();
+  });
+
+  it('Generates random UUIDs', () => {
+    for (let i = 0; i < 10; i++) {
+      const uuid = random.getUUID();
+      expect(validate(uuid)).toBeTruthy();
+      expect(uuid).not.toEqual(random.getUUID());
+    }
+  });
+
+  it('Generates random strings', () => {
+    for (let i = 0; i < 10; i++) {
+      const str = random.getString();
+      expect(str.length).toBeGreaterThan(5);
+      const words = str.split(' ');
+      expect(words.length).toEqual(5);
+      const set = new Set(words);
+      expect(set.size).toBeGreaterThan(1);
+    }
+  });
+});

--- a/src/__tests__/random.test.js
+++ b/src/__tests__/random.test.js
@@ -1,15 +1,21 @@
 import * as random from '../random';
 import validate from 'uuid-validate';
 
+const MIN_TRIES = 10; // make sure we fully test boundaries
+const MAX_TRIES = 1000;
+
 describe('random', () => {
   it('Generates random boolean values', () => {
     let hasTrue = false;
     let hasFalse = false;
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < MAX_TRIES; i++) {
       if (random.getBoolean()) {
         hasTrue = true;
       } else {
         hasFalse = true;
+      }
+      if (hasTrue && hasFalse) {
+        break;
       }
     }
     expect(hasTrue).toBeTruthy();
@@ -19,7 +25,7 @@ describe('random', () => {
   it('Generates random int values', () => {
     let hasMinusThree = false;
     let hasPlusThree = false;
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < MAX_TRIES; i++) {
       const rand = random.getInt(-3, 3);
       expect(rand).toBeGreaterThanOrEqual(-3);
       expect(rand).toBeLessThanOrEqual(3);
@@ -29,6 +35,9 @@ describe('random', () => {
       if (rand === 3) {
         hasPlusThree = true;
       }
+      if (i >= MIN_TRIES && hasMinusThree && hasPlusThree) {
+        break;
+      }
     }
     expect(hasMinusThree).toBeTruthy();
     expect(hasPlusThree).toBeTruthy();
@@ -37,7 +46,7 @@ describe('random', () => {
   it('Generates random float values', () => {
     let hasMinusThrees = false;
     let hasPlusThrees = false;
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < MAX_TRIES; i++) {
       const rand = random.getFloat(-4, 4);
       expect(rand).toBeGreaterThanOrEqual(-4);
       expect(rand).toBeLessThanOrEqual(4);
@@ -47,13 +56,16 @@ describe('random', () => {
       if (rand >= 3) {
         hasPlusThrees = true;
       }
+      if (i >= MIN_TRIES && hasMinusThrees && hasPlusThrees) {
+        break;
+      }
     }
     expect(hasMinusThrees).toBeTruthy();
     expect(hasPlusThrees).toBeTruthy();
   });
 
   it('Generates random UUIDs', () => {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < MIN_TRIES; i++) {
       const uuid = random.getUUID();
       expect(validate(uuid)).toBeTruthy();
       expect(uuid).not.toEqual(random.getUUID());
@@ -61,7 +73,7 @@ describe('random', () => {
   });
 
   it('Generates random strings', () => {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < MIN_TRIES; i++) {
       const str = random.getString();
       expect(str.length).toBeGreaterThan(5);
       const words = str.split(' ');

--- a/src/automock.js
+++ b/src/automock.js
@@ -1,7 +1,7 @@
-import casual from 'casual';
 import { GraphQLEnumType, getNullableType } from 'graphql';
 import { automockLists } from './list';
 import { automockRelay } from './relay';
+import * as random from './random';
 
 export function automockEnums(parentType, field) {
   const nullableType = getNullableType(field.type);
@@ -10,16 +10,15 @@ export function automockEnums(parentType, field) {
   }
 
   const values = nullableType.getValues().map(value => value.value);
-  return () => values[casual.integer(0, values.length - 1)];
+  return () => values[random.getInt(0, values.length - 1)];
 }
 
-// TODO Use `faker` once v5 is released
 export const scalarMocks = {
-  Boolean: () => casual.boolean,
-  ID: () => casual.uuid,
-  Int: () => casual.integer(-100, 100),
-  Float: () => casual.double(-100, 100),
-  String: () => casual.string
+  Boolean: () => random.getBoolean(),
+  ID: () => random.getUUID(),
+  Int: () => random.getInt(-100, 100),
+  Float: () => random.getFloat(-100, 100),
+  String: () => random.getString()
 };
 
 export function automockScalars(scalarMocks) {

--- a/src/random.js
+++ b/src/random.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { v1 as uuidv1 } from 'uuid';
 
 // borrowed from lorem-ipsum package
 export const WORDS = [
@@ -79,11 +79,7 @@ export function getFloat(min, max) {
 }
 
 export function getUUID() {
-  const seeds = [];
-  for (let i = 0; i < 16; i++) {
-    seeds[i] = getInt(0, 255);
-  }
-  return uuidv4({ random: seeds });
+  return uuidv1();
 }
 
 export function getString(wordCount = 5) {

--- a/src/random.js
+++ b/src/random.js
@@ -1,4 +1,3 @@
-import seedrandom from 'seedrandom';
 import { v4 as uuidv4 } from 'uuid';
 
 // borrowed from lorem-ipsum package
@@ -67,25 +66,22 @@ export const WORDS = [
   'voluptate'
 ];
 
-// seed the random number generator so we get consistent results
-const rng = seedrandom('graphql!');
-
 export function getInt(min, max) {
-  return (Math.abs(rng.int32()) % (max - min + 1)) + min;
+  return Math.floor(getFloat(min, max + 1));
 }
 
 export function getBoolean() {
-  return rng() > 0.5 ? true : false;
+  return Math.random() > 0.5 ? true : false;
 }
 
 export function getFloat(min, max) {
-  return rng() * (max - min) + min;
+  return Math.random() * (max - min) + min;
 }
 
 export function getUUID() {
   const seeds = [];
   for (let i = 0; i < 16; i++) {
-    seeds[i] = Math.abs(rng.int32()) % 256;
+    seeds[i] = getInt(0, 255);
   }
   return uuidv4({ random: seeds });
 }
@@ -93,7 +89,7 @@ export function getUUID() {
 export function getString(wordCount = 5) {
   const words = [];
   for (let i = 0; i < wordCount; i++) {
-    words[i] = WORDS[Math.abs(rng.int32()) % WORDS.length];
+    words[i] = WORDS[getInt(0, WORDS.length - 1)];
   }
   return words.join(' ');
 }

--- a/src/random.js
+++ b/src/random.js
@@ -1,0 +1,99 @@
+import seedrandom from 'seedrandom';
+import { v4 as uuidv4 } from 'uuid';
+
+// borrowed from lorem-ipsum package
+export const WORDS = [
+  'ad',
+  'adipisicing',
+  'aliqua',
+  'aliquip',
+  'amet',
+  'anim',
+  'aute',
+  'cillum',
+  'commodo',
+  'consectetur',
+  'consequat',
+  'culpa',
+  'cupidatat',
+  'deserunt',
+  'do',
+  'dolor',
+  'dolore',
+  'duis',
+  'ea',
+  'eiusmod',
+  'elit',
+  'enim',
+  'esse',
+  'est',
+  'et',
+  'eu',
+  'ex',
+  'excepteur',
+  'exercitation',
+  'fugiat',
+  'id',
+  'in',
+  'incididunt',
+  'ipsum',
+  'irure',
+  'labore',
+  'laboris',
+  'laborum',
+  'Lorem',
+  'magna',
+  'minim',
+  'mollit',
+  'nisi',
+  'non',
+  'nostrud',
+  'nulla',
+  'occaecat',
+  'officia',
+  'pariatur',
+  'proident',
+  'qui',
+  'quis',
+  'reprehenderit',
+  'sint',
+  'sit',
+  'sunt',
+  'tempor',
+  'ullamco',
+  'ut',
+  'velit',
+  'veniam',
+  'voluptate'
+];
+
+// seed the random number generator so we get consistent results
+const rng = seedrandom('graphql!');
+
+export function getInt(min, max) {
+  return (Math.abs(rng.int32()) % (max - min + 1)) + min;
+}
+
+export function getBoolean() {
+  return rng() > 0.5 ? true : false;
+}
+
+export function getFloat(min, max) {
+  return rng() * (max - min) + min;
+}
+
+export function getUUID() {
+  const seeds = [];
+  for (let i = 0; i < 16; i++) {
+    seeds[i] = Math.abs(rng.int32()) % 256;
+  }
+  return uuidv4({ random: seeds });
+}
+
+export function getString(wordCount = 5) {
+  const words = [];
+  for (let i = 0; i < wordCount; i++) {
+    words[i] = WORDS[Math.abs(rng.int32()) % WORDS.length];
+  }
+  return words.join(' ');
+}

--- a/src/relay.js
+++ b/src/relay.js
@@ -1,5 +1,5 @@
 // @flow
-import casual from 'casual';
+import { getUUID } from './random';
 import { mockList } from './list';
 import { GraphQLObjectType } from 'graphql';
 
@@ -75,7 +75,7 @@ export function automockRelay(parentType, field) {
 
   if (isRelayNode(parentType)) {
     if (field.name === 'id') {
-      return () => casual.uuid;
+      return () => getUUID();
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,14 +1436,6 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-casual@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/casual/-/casual-1.6.2.tgz#f56b87113ae99a6bba45e04bdfa068ca443f9e85"
-  integrity sha512-NQObL800rg32KZ9bBajHbyDjxLXxxuShChQg7A4tbSeG3n1t7VYGOSkzFSI9gkSgOHp+xilEJ7G0L5l6M30KYA==
-  dependencies:
-    mersenne-twister "^1.0.1"
-    moment "^2.15.2"
-
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -2203,11 +2195,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
-  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
-
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
@@ -2657,7 +2644,7 @@ graphql-tools@^4.0.4:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^0.14.6:
+graphql@14.6.0:
   version "14.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
   integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
@@ -4212,11 +4199,6 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
-mersenne-twister@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
-  integrity sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=
-
 micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -4333,11 +4315,6 @@ mixin-deep@^1.2.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-moment@^2.15.2:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 ms@2.0.0:
   version "2.0.0"
@@ -5409,6 +5386,11 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -6169,10 +6151,20 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
+uuid-validate@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/uuid-validate/-/uuid-validate-0.0.3.tgz#e30617f75dc742a0e4f95012a11540faf9d39ab4"
+  integrity sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==
+
 uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
 
 v8flags@^3.1.1:
   version "3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5386,11 +5386,6 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-seedrandom@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
-  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
-
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"


### PR DESCRIPTION
The `casual` library has a dependency on 'fs' for lazy loading, which makes it impossible to use `graphql-mock-factory` for in-browser use (for instance for storybook). Since we don't really need much of that functionality, and the alternatives (like `faker`) are also quite bloated and not well-maintained, this PR replaces both of these with some simple functions that generate random numbers and strings. In addition, it uses the `uuid` library to generate valid UUIDs (not that it particularly matters for test data).